### PR TITLE
Adding CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# ref: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# CODEOWNERS include members of the osm-maintainers team - https://github.com/orgs/openservicemesh/teams/osm-maintainers/members
+# CODEOWNERS include members of the osm-www team - https://github.com/orgs/openservicemesh/teams/osm-www/members
+* @openservicemesh/osm-maintainers @openservicemesh/osm-www


### PR DESCRIPTION
As suggested by @lachie83, this clarifies who the CODEOWNERS are.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>