### PR TITLE
add the docs site to the menu

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,8 @@ params:
   navbar:
   - title: Home
     url: /
+  - title: Docs
+    url: https://docs.openservicemesh.io
   - title: Github
     url: https://github.com/openservicemesh/osm
   - title: Blog


### PR DESCRIPTION
<img width="446" alt="Screen Shot 2021-01-28 at 9 50 33 AM" src="https://user-images.githubusercontent.com/686194/106178173-4a7d4880-614e-11eb-8492-5131e70f110c.png">

Setting this up - adding this link will make the docs.openservicemesh.io site accessible to the public. 
This should not get merged until @phillipgibson gives the 👍 

Signed-off-by: flynnduism <dev@ronan.design>